### PR TITLE
Updated Dockerfile to point to Ubuntu CUDA images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# The official install talks about Fedora packages, so let's see
-# if Centos is close enough...
-FROM nvidia/cuda:9.0-devel-centos7
+# Pull the Ubuntu CUDA development image
+FROM nvidia/cuda:9.0-devel-ubuntu16.04
+
+# Update repos
+RUN apt-get -qq update
 
 # We will need Git to pull the repo
-RUN yum -y -q install git
+RUN apt-get -qq -y install --no-install-recommends git
 
-# The packages mentioned in the INSTALL phase, except:
-# jansson-devel - We're going to build our own since the version 2.4.x doesn't have json_array_foreach
-# make - Added it because Centos doesn't have it even after getting autoconf/automake
-RUN yum -y -q install gcc gcc-c++ make wget autoconf automake install openssl-devel libcurl-devel zlib-devel
+# The packages mentioned in the INSTALL phase, plus gcc-5 and g++-5
+RUN apt-get -qq -y install --no-install-recommends ca-certificates libcurl4-openssl-dev libssl-dev libjansson-dev automake autotools-dev build-essential gcc-5 g++-5
 
 # Create a user to do the build
 ENV BUILD_FOLDER=/minerbuild
@@ -19,34 +19,6 @@ ENV CCMINER_VERSION=cuda-9
 RUN adduser $APP_USER && \
     mkdir $BUILD_FOLDER && \
     chown $APP_USER.users $BUILD_FOLDER
-
-# We'll build jansson as regular user
-USER $APP_USER
-
-# Download jansson and verify signature (since we're downloading over HTTP)
-
-RUN cd $BUILD_FOLDER && \
-    wget http://www.digip.org/jansson/releases/jansson-2.10.tar.gz && \
-    gpg --keyserver pgp.mit.edu --recv-keys D058434C && \
-    wget http://www.digip.org/jansson/releases/jansson-2.10.tar.gz.asc && \
-    gpg --verify jansson-2.10.tar.gz.asc jansson-2.10.tar.gz
-
-# Extract jasson
-RUN cd $BUILD_FOLDER && \
-    tar -xvf jansson-2.10.tar.gz && \
-    rm jansson-2.10.tar.gz && \
-    rm jansson-2.10.tar.gz.asc
-
-# Build Jansson
-RUN cd $BUILD_FOLDER/jansson-2.10 && \
-    ./configure && \
-    make && \
-    make check
-
-# Install Jansson (need root for this)
-USER root
-RUN cd $BUILD_FOLDER/jansson-2.10 && \
-    make install
  
 # Now switch to the builder and check out the git repo
 USER $APP_USER
@@ -67,7 +39,7 @@ RUN mkdir $APP_FOLDER && \
     cp $BUILD_FOLDER/ccminer/ccminer $APP_FOLDER
 
 # Switch to a multistage build with the runtime image
-FROM nvidia/cuda:9.0-runtime-centos7
+FROM nvidia/cuda:9.0-runtime-ubuntu16.04
 
 # Redefine the app user and folder - note app folder must be the same as the first stage
 ENV APP_FOLDER=/app
@@ -78,13 +50,10 @@ COPY --from=0 $APP_FOLDER $APP_FOLDER
 COPY --from=0 /usr/local/lib /usr/local/lib
 
 # Get the non-devel versions of the libraries that we need
-RUN yum -y -q install openssl libcurl zlib libgomp &&  \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
-# Load the Jansson library that's now built
-RUN echo /usr/local/lib > /etc/ld.so.conf.d/userlocal.conf && \
-    ldconfig
+RUN apt-get -qq update && \
+    apt-get -qq -y install --no-install-recommends libcurl3 libgomp1 libjansson4 && \
+    apt-get clean autoclean && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Symlink the app to /usr/local/bin
 RUN ln -s $APP_FOLDER/ccminer /usr/local/bin/ccminer && \
@@ -94,4 +63,8 @@ RUN ln -s $APP_FOLDER/ccminer /usr/local/bin/ccminer && \
 RUN adduser $APP_USER
 USER $APP_USER
 
-CMD [ ccminer ]
+# Set the entrypoint for all comsole connections
+ENTRYPOINT ["ccminer"]
+
+# Set the default command
+CMD [ "-h" ]


### PR DESCRIPTION
- Removed all the CentOS specific options
- Added a few options to quiet the build output
- Changed the ENTRYPOINT and CMD options so that arguments can be queried directly from the docker image